### PR TITLE
스팀키체인 거래내역 및 댓글 내역 불러오기 오류 수정

### DIFF
--- a/_locales/ko/messages.json
+++ b/_locales/ko/messages.json
@@ -300,7 +300,7 @@
     "description": "on import / export settings"
   },
   "popup_html_about_text": {
-    "message": "Steem Keychain 브라우저 확장 프로그램 <br>아이디어와 컨셉은 스팀 블록체인 증인이자 개발자로 활동 중인 <a href=\"https://steemit.com/@yabapmatt\" target=\"_blank\">@yabapmatt</a>이 구상한 것입니다. 스팀 증인이자 스팀 개발자(SteemPlus)인 <a href=\"https://steemit.com/@stoodkev\" target=\"_blank\">@stoodkev</a>가 Steem Keychain 기능 대부분을 개발했습니다. 설계와 개발 자금은 @aggroed (스팀 상위 20 위 증인 중 한 명), @yabapmatt 이 함께 운영하는 블록체인 기반 수집 카드 거래 게임인 Splinterlands를 통해 지원받았습니다. <a href=\"https://splinterlands.io\" target=\"_blank\">https://splinterlands.io</a>를 방문하시면 Splinterlands에 대해 더 자세한 정보를 확인하실 수 있습니다! (* Steem/Hive 하드포크 이후 기존 개발자는 Hive에서 활동중이기 때문에, Steem 커뮤니티 운영자인 <a href=\"https://steemcoinpan.com\" target=\"_blank\">Steemcoinpan</a>의 개발자가 유지보수 하고 있습니다.)",
+    "message": "Steem Keychain 브라우저 확장 프로그램 <br>아이디어와 컨셉은 스팀 블록체인 증인이자 개발자로 활동 중인 <a href=\"https://steemit.com/@yabapmatt\" target=\"_blank\">@yabapmatt</a>이 구상한 것입니다. 스팀 증인이자 스팀 개발자(SteemPlus)인 <a href=\"https://steemit.com/@stoodkev\" target=\"_blank\">@stoodkev</a>가 Steem Keychain 기능 대부분을 개발했습니다. 설계와 개발 자금은 @aggroed (스팀 상위 20 위 증인 중 한 명), @yabapmatt 이 함께 운영하는 블록체인 기반 수집 카드 거래 게임인 Splinterlands를 통해 지원받았습니다. <a href=\"https://splinterlands.io\" target=\"_blank\">https://splinterlands.io</a>를 방문하시면 Splinterlands에 대해 더 자세한 정보를 확인하실 수 있습니다! (* Steem/Hive 하드포크 이후 기존 개발자는 Hive에서 활동중이기 때문에, Steem 커뮤니티 운영자인 <a href=\"https://upvu.org\" target=\"_blank\">Upvu</a>의 개발자가 유지보수 하고 있습니다.)",
     "description": "on about keychain"
   },
   "popup_html_remove": {

--- a/_locales/zh_TW/messages.json
+++ b/_locales/zh_TW/messages.json
@@ -1121,7 +1121,7 @@
     "message": "播送此交易時出錯："
   },
   "bgd_ops_transfer_success": {
-    "message": "已成功將$1$2從@$3轉移到@$4。"
+    "message": "已成功將$1 $2從@$3轉移到@$4。"
   },
   "bgd_ops_tokens": {
     "message": "交易已成功播送。 請檢查您的餘額以確認過程是否已成功。"

--- a/html/popup.html
+++ b/html/popup.html
@@ -118,7 +118,7 @@
       </div>
       <button class="dash-button main-button" id="send"></button>
       <button class="dash-button main-button" id="history"></button>
-      <button class="dash-button main-button" id="tokens"></button>
+      <!-- <button class="dash-button main-button" id="tokens"></button> -->
       <button class="dash-button main-button" id="witness"></button>
       <button class="dash-button main-button" id="comments"></button>
       <button class="dash-button main-button" id="NFTs"></button>

--- a/js/libs/account.js
+++ b/js/libs/account.js
@@ -1,7 +1,7 @@
 class Account {
   constructor(obj) {
     this.account = obj || {};
-    this.maxAccountHistoryAmount = 100;
+    this.maxAccountHistoryAmount = 20;
   }
   init() {
     this.info = steem.api.getAccountsAsync([this.account.name]);

--- a/js/popup/accounts.js
+++ b/js/popup/accounts.js
@@ -59,10 +59,10 @@ const loadAccount = async (name) => {
   prepareWitnessDiv(witness_votes, proxy);
   prepareDelegationTab();
   preparePowerUpDown();
-  showTokenBalances();
+  // showTokenBalances();
   proposeWitnessVote(witness_votes, proxy);
   getAccountHistory();
-  getAccountComments();
+  // getAccountComments();
   setNFTs();
 };
 
@@ -98,12 +98,14 @@ const showUserData = async () => {
 };
 
 const getAccountHistory = async () => {
-  $("#acc_transfers div")
-    .eq(1)
-    .append("<div><center>Loading...</center></div>");
+  const transfersDiv = $("#acc_transfers div").eq(1);
+  const commentsDiv = $("#acc_comments div").eq(1);
+  transfersDiv.empty().append("<div><center>Loading...</center></div>");
+  commentsDiv.empty().append("<div><center>Loading...</center></div>");
 
-  const transfers = await activeAccount.getTransfers();
-  $("#acc_transfers div").eq(1).empty();
+  const { transfers, comments } = await activeAccount.getAccountHistory();
+
+  transfersDiv.empty();
   if (transfers.length != 0) {
     for (transfer of transfers) {
       let memo = transfer[1].op[1].memo;
@@ -139,23 +141,20 @@ const getAccountHistory = async () => {
       var memo_element = $("<div class='memo'></div>");
       memo_element.text(memo);
       transfers_element.append(memo_element);
-      $("#acc_transfers div").eq(1).append(transfers_element);
+      transfersDiv.append(transfers_element);
     }
     $(".transfer_row").click(function () {
       $(".memo").eq($(this).index()).slideToggle();
     });
-  } else
-    $("#acc_transfers div")
-      .eq(1)
-      .append(`<div class="transfer_row">${NO_RECENT_TRANSFERS}</div>`);
-};
+  } else {
+    transfersDiv.append(
+      `<div class="transfer_row">${NO_RECENT_TRANSFERS}</div>`
+    );
+  }
 
-const getAccountComments = async () => {
-  const transfers = await activeAccount.getComments();
-  console.log(transfers);
-  $("#acc_comments div").eq(1).empty();
-  if (transfers.length != 0) {
-    for (transfer of transfers) {
+  commentsDiv.empty();
+  if (comments.length != 0) {
+    for (transfer of comments) {
       let author = transfer[1].op[1].author;
       let comment = transfer[1].op[1].body;
       let permlink = transfer[1].op[1].parent_permlink;
@@ -180,15 +179,14 @@ const getAccountComments = async () => {
           comment +
           "</div></div>"
       );
-      $("#acc_comments div").eq(1).append(transfers_element);
+      commentsDiv.append(transfers_element);
     }
     $(".comment_row").click(function () {
       // location.href = '/' + $(this).attr('permlink');
     });
-  } else
-    $("#acc_comments div")
-      .eq(1)
-      .append(`<div class="comment_row">${NO_RECENT_TRANSFERS}</div>`);
+  } else {
+    commentsDiv.append(`<div class="comment_row">${NO_RECENT_TRANSFERS}</div>`);
+  }
 };
 
 // Adding accounts. Private keys can be entered individually or by the mean of the

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "SteemKeychain",
   "description": "Steem keychain",
   "default_locale": "en",
-  "version": "1.0.34",
+  "version": "1.0.35",
   "permissions": ["storage"],
   "browser_action": {
     "default_popup": "html/popup.html",


### PR DESCRIPTION
[수정 내용]
- getAccountHistory API의 호출 limit을 20개씩, 1초당 9회로 변경. 거래내역과 댓글내역을 동시에 조회하도록 변경.
- 스팀엔진 토큰 메뉴 제거 (스팀엔진 토큰 서비스 종료됨)
- 스팀키체인 소개 문구 일부 수정 (스팀코인판 커뮤니티 없어짐, Upvu로 문구 변경)
